### PR TITLE
Start making file uploading more robust

### DIFF
--- a/templates/parse_file.html
+++ b/templates/parse_file.html
@@ -37,7 +37,7 @@ $(document).ready(function(){
             <table class="table table-striped">
                 <thead><tr><th>File Column Name</th><th>Real Column Name</th><th>Units</th></tr></thead>
                 <tbody>
-                <tr><td>  <input type="checkbox" name="issimulated" value="issimulated">Is simulated? </td></tr>
+                <tr><td>  <input type="checkbox" name="issimulated" value="IsSimulated">Is simulated? </td></tr>
                 
                 {% for column_name,best_column_name in zip(table.colnames, best_column_names) %}
                 <tr>

--- a/templates/upload_form_filetype.html
+++ b/templates/upload_form_filetype.html
@@ -7,6 +7,24 @@
 
 {% block scripts %}
 {{ super() }}
+<script>
+$(document).ready(function(){
+    if($('#file_field').val() == ''){
+        $('#upload_button').attr('disabled','disabled');
+    }
+
+    $('#file_field').change(function(){
+        var value = $(this).val();
+        console.log(value);
+        if(value != ''){
+            $('#upload_button').removeAttr('disabled');
+        }
+        else{
+            $('#upload_button').attr('disabled','disabled');
+        }
+    })
+});
+</script>
 {% endblock %}
 
 {% block body %}
@@ -18,7 +36,7 @@
                 <div class="input-group">
                     <label class="sr-only" for="file">Choose File and specify file type</label>
                     <!-- TODO: add a callback that finds the best-match format when a filename is set -->
-                    <input class="form-control" type="file" name="file" value={{filename}}>
+                    <input class="form-control" id="file_field" type="file" name="file" value={{filename}}>
                     <input class="fileformat" name="fileformat" value={{best_match_extension}}>
                     <input class="btn btn-success" id="upload_button" type="submit" value="Upload">
                 </div>    

--- a/upload_form.py
+++ b/upload_form.py
@@ -180,7 +180,8 @@ def set_columns(filename, fileformat=None):
     
     units_data = {}
     for _, pair in column_data.items():
-        if pair['Name'] != "Ignore":
+        print "Pair Name", pair['Name']
+        if pair['Name'] != "Ignore" and pair['Name'] != "IsSimulated":
             units_data[pair['Name']] = pair['unit']
 
     print 'units_data:', units_data    

--- a/upload_form.py
+++ b/upload_form.py
@@ -180,7 +180,6 @@ def set_columns(filename, fileformat=None):
     
     units_data = {}
     for _, pair in column_data.items():
-        print "Pair Name", pair['Name']
         if pair['Name'] != "Ignore" and pair['Name'] != "IsSimulated":
             units_data[pair['Name']] = pair['unit']
 


### PR DESCRIPTION
In the first file upload page, we disable the upload button until a filename is specified. This set of changes does the same for the file upload with filetype page. It also includes some bugfixes for the handling of the issimulated checkbox.
