### PR TITLE
 Don't allow submit button to be pushed until filetype is specified

### DIFF
--- a/templates/upload_form_filetype.html
+++ b/templates/upload_form_filetype.html
@@ -9,14 +9,26 @@
 {{ super() }}
 <script>
 $(document).ready(function(){
-    if($('#file_field').val() == ''){
+    if($('#file_field').val() == '' || $('#file_format').val() == ''){
         $('#upload_button').attr('disabled','disabled');
     }
 
     $('#file_field').change(function(){
         var value = $(this).val();
+        var value2 = $('#file_format').val();
         console.log(value);
-        if(value != ''){
+        if(value != '' && value2 != ''){
+            $('#upload_button').removeAttr('disabled');
+        }
+        else{
+            $('#upload_button').attr('disabled','disabled');
+        }
+    })
+
+    $('#file_format').change(function(){
+        var value = $(this).val();
+        var value2 = $('#file_field').val();
+        if(value != '' && value2 != ''){
             $('#upload_button').removeAttr('disabled');
         }
         else{
@@ -37,7 +49,7 @@ $(document).ready(function(){
                     <label class="sr-only" for="file">Choose File and specify file type</label>
                     <!-- TODO: add a callback that finds the best-match format when a filename is set -->
                     <input class="form-control" id="file_field" type="file" name="file" value={{filename}}>
-                    <input class="fileformat" name="fileformat" value={{best_match_extension}}>
+                    <input class="fileformat" id="file_format" name="fileformat" value={{best_match_extension}}>
                     <input class="btn btn-success" id="upload_button" type="submit" value="Upload">
                 </div>    
             </div>


### PR DESCRIPTION
Submitting with an empty filetype gives a very unhelpful HTML error, so don't let this happen in the first place. As a bonus, this also fixes a bug in the autocomplete code, which assumed the existence of file_format.
