### PR TITLE
add a filename column

### DIFF
--- a/ingest_datasets_better.py
+++ b/ingest_datasets_better.py
@@ -87,6 +87,12 @@ def add_name_column(tbl, name):
     """
     tbl.add_column(table.Column(name='Names', data=[name]*len(tbl)), index=0)
 
+def add_filename_column(tbl, filename):
+    """
+    Add the filename as a column
+    """
+    tbl.add_column(table.Column(name='Filename', data=[filename]*len(tbl)))
+
 def append_table(merged_table, table_to_add):
     """
     Append a new table to the original

--- a/templates/show_plot.html
+++ b/templates/show_plot.html
@@ -7,6 +7,7 @@
 
 {% block scripts %}
 {{ super() }}
+<script src="http://cdn.datatables.net/1.10.2/js/jquery.dataTables.min.js"></script>
 {% endblock %}
 
 {% block body %}
@@ -20,7 +21,6 @@ imagename = {{imagename}}
 <hr>
  <div id="includedContent"></div>
 
-<script src="jquery.js"></script> 
 <script> 
 $(function(){
         $("#includedContent").load("/static/jstables/{{tablefile}}"); 

--- a/templates/show_plot.html
+++ b/templates/show_plot.html
@@ -16,5 +16,15 @@ This is a page with a figure
 imagename = {{imagename}}
 <img src="{{imagename}}" width=800>
 
+<br>
+<hr>
+ <div id="includedContent"></div>
+
+<script src="jquery.js"></script> 
+<script> 
+$(function(){
+        $("#includedContent").load("/static/jstables/{{tablefile}}"); 
+});
+</script> 
 
 {% endblock %}

--- a/upload_form.py
+++ b/upload_form.py
@@ -19,6 +19,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.io import ascii
 from astropy import table
+from astropy.table.jsviewer import write_table_jsviewer
 from astropy import units as u
 from ingest_datasets_better import (rename_columns, set_units, convert_units,
                                     add_name_column, add_generic_ids_if_needed,
@@ -238,9 +239,11 @@ def set_columns(filename, fileformat=None):
     myplot = plotData(timeString(), table, 'static/figures/'+outfilename)
 
     tablecss = "table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}"
-    table.write('static/jstables/{fn}.html'.format(fn=outfilename),
-                format='jsviewer', css=tablecss,
-                jskwargs={'use_local_files':False}, table_id=outfilename)
+    write_table_jsviewer(table,
+                         'static/jstables/{fn}.html'.format(fn=outfilename),
+                         css=tablecss,
+                         jskwargs={'use_local_files':False},
+                         table_id=outfilename)
 
     return render_template('show_plot.html', imagename='/'+myplot,
                            tablefile='{fn}.html'.format(fn=outfilename))

--- a/upload_form.py
+++ b/upload_form.py
@@ -22,7 +22,9 @@ from astropy import table
 from astropy import units as u
 from ingest_datasets_better import (rename_columns, set_units, convert_units,
                                     add_name_column, add_generic_ids_if_needed,
-                                    add_is_sim_if_needed, fix_bad_types)
+                                    add_is_sim_if_needed, fix_bad_types,
+                                    add_filename_column,
+                                   )
 from flask import (Flask, request, redirect, url_for, render_template,
                    send_from_directory, jsonify)
 from simple_plot import plotData, timeString
@@ -217,17 +219,19 @@ def set_columns(filename, fileformat=None):
         if pair['Name'] != "Ignore" and pair['Name'] != "IsSimulated" and key != "Username":
             units_data[pair['Name']] = pair['unit']
 
+    # Parse the table file, step-by-step
     rename_columns(table, {k: v['Name'] for k,v in column_data.items()})
     set_units(table, units_data)
     table = fix_bad_types(table)
-    print(table)
     convert_units(table)
     add_name_column(table, column_data.get('Username')['Name'])
-    print(table)
+    add_filename_column(table, filename)
     add_generic_ids_if_needed(table)
     add_is_sim_if_needed(table)
+
     if not os.path.isdir('static/figures/'):
         os.mkdir('static/figures')
+
     myplot = plotData(timeString(), table, 'static/figures/'+filename)
 
     return render_template('show_plot.html', imagename='/'+myplot)#url_for('static',filename='figures/'+myplot))

--- a/upload_form.py
+++ b/upload_form.py
@@ -239,7 +239,7 @@ def set_columns(filename, fileformat=None):
 
     tablecss = "table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}"
     table.write('static/jstables/{fn}.html'.format(fn=outfilename),
-                format='jsviewer', css=tablecss, 
+                format='jsviewer', css=tablecss,
                 jskwargs={'use_local_files':True}, table_id=outfilename)
 
     return render_template('show_plot.html', imagename='/'+myplot,

--- a/upload_form.py
+++ b/upload_form.py
@@ -240,7 +240,7 @@ def set_columns(filename, fileformat=None):
     tablecss = "table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}"
     table.write('static/jstables/{fn}.html'.format(fn=outfilename),
                 format='jsviewer', css=tablecss,
-                jskwargs={'use_local_files':True}, table_id=outfilename)
+                jskwargs={'use_local_files':False}, table_id=outfilename)
 
     return render_template('show_plot.html', imagename='/'+myplot,
                            tablefile='{fn}.html'.format(fn=outfilename))

--- a/upload_form.py
+++ b/upload_form.py
@@ -231,10 +231,19 @@ def set_columns(filename, fileformat=None):
 
     if not os.path.isdir('static/figures/'):
         os.mkdir('static/figures')
+    if not os.path.isdir('static/jstables/'):
+        os.mkdir('static/jstables')
 
-    myplot = plotData(timeString(), table, 'static/figures/'+filename)
+    outfilename = os.path.splitext(filename)[0]
+    myplot = plotData(timeString(), table, 'static/figures/'+outfilename)
 
-    return render_template('show_plot.html', imagename='/'+myplot)#url_for('static',filename='figures/'+myplot))
+    tablecss = "table,th,td,tr,tbody {border: 1px solid black; border-collapse: collapse;}"
+    table.write('static/jstables/{fn}.html'.format(fn=outfilename),
+                format='jsviewer', css=tablecss, 
+                jskwargs={'use_local_files':True}, table_id=outfilename)
+
+    return render_template('show_plot.html', imagename='/'+myplot,
+                           tablefile='{fn}.html'.format(fn=outfilename))
 
 
 


### PR DESCRIPTION
If we have a filename column, we can eventually turn it into links to the underlying data files.

The generic plan is to store each submitted file on disk (not allowing overwrites...) along with the submitted metadata (e.g., column name mapping, username, ...) so that we can fully reproduce the submission process.

cc @scog1234
