### PR TITLE
Fix bug in setting units of new merged table

### DIFF
--- a/upload_form.py
+++ b/upload_form.py
@@ -242,7 +242,7 @@ def set_columns(filename, fileformat=None):
 #       and verify that submitted data obeys these limits
         merged_table = Table(data=None, names=['Names','IDs','SurfaceDensity',
                        'VelocityDispersion','Radius','IsSimulated'], dtype=[('str', 64),('str', 64),'float','float','float','bool'])
-        set_units(merged_table, units_data)
+        set_units(merged_table)
 
     table = reorder_columns(table, merged_table.colnames)
     append_table(merged_table, table)


### PR DESCRIPTION
We need to make sure that we set the units of the columns in the merged table to our default values, which won't necessarily be the same as the values in the input file
