### PR TITLE
Fix truncation bug when appending to merged_table

### DIFF
--- a/upload_form.py
+++ b/upload_form.py
@@ -233,16 +233,16 @@ def set_columns(filename, fileformat=None):
     else:
         add_is_sim_if_needed(table, True)
 
-# If merged table already exists, then append the new entries.
-# Otherwise, create the table
+    # If merged table already exists, then append the new entries.
+    # Otherwise, create the table
 
     merged_table_name = os.path.join(app.config['UPLOAD_FOLDER'], 'merged_table.ipac')
     if os.path.isfile(merged_table_name):
         merged_table = Table.read(merged_table_name, format='ascii.ipac')
     else:
-# Maximum strength length of 64 for username, ID -- larger strings are silently truncated
-# TODO: Adjust these numbers to something more reasonable, once we figure out what that is,
-#       and verify that submitted data obeys these limits
+    # Maximum string length of 64 for username, ID -- larger strings are silently truncated
+    # TODO: Adjust these numbers to something more reasonable, once we figure out what that is,
+    #       and verify that submitted data obeys these limits
         merged_table = Table(data=None, names=['Names','IDs','SurfaceDensity',
                        'VelocityDispersion','Radius','IsSimulated'], dtype=[('str', 64),('str', 64),'float','float','float','bool'])
         set_units(merged_table)

--- a/upload_form.py
+++ b/upload_form.py
@@ -238,7 +238,7 @@ def set_columns(filename, fileformat=None):
 
     merged_table_name = os.path.join(app.config['UPLOAD_FOLDER'], 'merged_table.ipac')
     if os.path.isfile(merged_table_name):
-        merged_table = Table.read(merged_table_name, format='ascii.ipac')
+        merged_table = Table.read(merged_table_name, converters={'Names': [ascii.convert_numpy('S64')], 'IDs': [ascii.convert_numpy('S64')]}, format='ascii.ipac')
     else:
     # Maximum string length of 64 for username, ID -- larger strings are silently truncated
     # TODO: Adjust these numbers to something more reasonable, once we figure out what that is,


### PR DESCRIPTION
The previous version of the merged_table logic suffered from a major bug, in that the size of the 'Names' and 'IDs' columns was set by the first value stored in each. This means that if you first stored entries with e.g. 'Names' = "Simon" and then stored entries with 'Names' = "Diederik", the second set would get truncated to "Diede". The same problem also existed for the "IDs" field. To fix this, we need to explicitly convert these columns to wider strings when we read them in.
