### PR TITLE
Fix another truncation bug

### DIFF
--- a/upload_form.py
+++ b/upload_form.py
@@ -238,7 +238,8 @@ def set_columns(filename, fileformat=None):
 
     merged_table_name = os.path.join(app.config['UPLOAD_FOLDER'], 'merged_table.ipac')
     if os.path.isfile(merged_table_name):
-        merged_table = Table.read(merged_table_name, converters={'Names': [ascii.convert_numpy('S64')], 'IDs': [ascii.convert_numpy('S64')]}, format='ascii.ipac')
+        merged_table = Table.read(merged_table_name, converters={'Names': [ascii.convert_numpy('S64')], 
+        'IDs': [ascii.convert_numpy('S64')], 'IsSimulated': [ascii.convert_numpy('S5')]}, format='ascii.ipac')
     else:
     # Maximum string length of 64 for username, ID -- larger strings are silently truncated
     # TODO: Adjust these numbers to something more reasonable, once we figure out what that is,


### PR DESCRIPTION
The IsSimulated column has a similar truncation bug to the ones I recently fixed for the name and ID columns. If the first entry in the merged table has a status of 'True', then in subsequent entries 'False' gets truncated to 'Fals'. This commit fixes this problem. 
